### PR TITLE
Prevent accesschk subprocess from opening console windows

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ AccessChk GUI — v1.4
 • Barre de progression + compteur de lignes
 
 Build EXE (optionnel) :
-pyinstaller --onefile --name AccessChkGUI accesschk_gui_tk.py
+pyinstaller --onefile --noconsole --name AccessChkGUI accesschk_gui_tk.py
 # (ne pas utiliser --add-binary ; place accesschk.exe manuellement à côté du .exe)
 
 Conseils Principal :

--- a/accesschk_gui_tk.py
+++ b/accesschk_gui_tk.py
@@ -150,7 +150,20 @@ class AccessChkGUI(tk.Tk):
                     if not who: continue
                     # RW + récursif + sans bandeau
                     args = [accesschk, "-accepteula", "-nobanner", who, "-w", "-s", target]
-                    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    startupinfo = None
+                    creationflags = 0
+                    if os.name == "nt":
+                        startupinfo = subprocess.STARTUPINFO()
+                        startupinfo.dwFlags |= getattr(subprocess, "STARTF_USESHOWWINDOW", 0)
+                        creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
+                    proc = subprocess.Popen(
+                        args,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        startupinfo=startupinfo,
+                        creationflags=creationflags,
+                    )
                     self.proc = proc
 
                     invalid = False

--- a/build_gui.ps1
+++ b/build_gui.ps1
@@ -17,6 +17,7 @@ $pip = Join-Path $venv "Scripts\pip.exe"
 $spec = @(
   "--onefile",
   "--noconfirm",
+  "--noconsole",
   "--name","AccessChkGUI",
   "accesschk_gui_tk.py"
 )


### PR DESCRIPTION
## Summary
- configure the accesschk invocation to use Windows startup info with CREATE_NO_WINDOW
- ensure GUI scans run without spawning extra console windows

## Testing
- not run (GUI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e552f58ff0832a917b3ee77948072c